### PR TITLE
100 msg to json

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -118,6 +118,9 @@ func ConnectAndDiscover(target string) {
 	}
 	peer.ConnectionHandler(c)
 	p := peer.PStore.Get(c.RemoteAddr().String())
+	if p == nil {
+		log.Fatal("Failed to exchange listen addresses with target peer")
+	}
 	p.Request(peerInfoRequest, peer.PeerInfoHandler)
 }
 

--- a/msg/message.go
+++ b/msg/message.go
@@ -73,7 +73,7 @@ type MessagePayload interface {
 // should specify block number in parameters.
 type Request struct {
 	ID           string                 `json:"ID"`
-	ResourceType ResourceType           `json:""`
+	ResourceType ResourceType           `json:"ResourceType"`
 	Params       map[string]interface{} `json:"Params"`
 }
 

--- a/msg/message.go
+++ b/msg/message.go
@@ -37,8 +37,8 @@ const (
 
 // ProtocolError is an error that occured during a request.
 type ProtocolError struct {
-	Code    ErrorCode `json:"Code"`
-	Message string    `json:"Message"`
+	Code    ErrorCode
+	Message string
 }
 
 // NewProtocolError returns a new error struct.
@@ -56,8 +56,8 @@ func (e *ProtocolError) Error() string {
 // Payload must be a marshalled representation of a Request, Response, or Push
 // when the message is sent.
 type Message struct {
-	Type    string `json:"Type"`
-	Payload []byte `json:"Payload"`
+	Type    string
+	Payload []byte
 }
 
 // MessagePayload is an interface that is implemented by Request, Response, and
@@ -72,25 +72,25 @@ type MessagePayload interface {
 // parameters. PeerInfo requests should send all info of all peers. Block requests
 // should specify block number in parameters.
 type Request struct {
-	ID           string                 `json:"ID"`
-	ResourceType ResourceType           `json:"ResourceType"`
-	Params       map[string]interface{} `json:"Params"`
+	ID           string
+	ResourceType ResourceType
+	Params       map[string]interface{}
 }
 
 // Response is a container for a response payload, containing the unique request
 // ID of the request prompting it, an Error (if one occurred), and the requested
 // resource (if no error occurred).
 type Response struct {
-	ID       string         `json:"ID"`
-	Error    *ProtocolError `json:"Error"`
-	Resource interface{}    `json:"Resource"`
+	ID       string
+	Error    *ProtocolError
+	Resource interface{}
 }
 
 // Push is a container for a push payload, containing a resource proactively sent
 // to us by another peer.
 type Push struct {
-	ResourceType ResourceType `json:"ResourceType"`
-	Resource     interface{}  `json:"Resource"`
+	ResourceType ResourceType
+	Resource     interface{}
 }
 
 // Write encodes and writes the Message into the given Writer.

--- a/msg/message_test.go
+++ b/msg/message_test.go
@@ -22,13 +22,14 @@ func TestRequest(t *testing.T) {
 		t.Fail()
 	}
 
-	req, _, _, err := Read(&buf)
+	payload, err := Read(&buf)
 	if err != nil {
 		t.Log(err.Error())
 		t.Fail()
 	}
 
-	if req.ID != id {
+	req, ok := payload.(*Request)
+	if !ok || req.ID != id {
 		t.Fail()
 	}
 }
@@ -48,13 +49,14 @@ func TestResponse(t *testing.T) {
 		t.Fail()
 	}
 
-	_, res, _, err := Read(&buf)
+	payload, err := Read(&buf)
 	if err != nil {
 		t.Log(err.Error())
 		t.Fail()
 	}
 
-	if res.ID != id {
+	res, ok := payload.(*Response)
+	if !ok || res.ID != id {
 		t.Fail()
 	}
 
@@ -82,9 +84,14 @@ func TestPush(t *testing.T) {
 		t.Fail()
 	}
 
-	_, _, push, err := Read(&buf)
+	payload, err := Read(&buf)
 	if err != nil {
 		t.Log(err.Error())
+		t.Fail()
+	}
+
+	push, ok := payload.(*Push)
+	if !ok {
 		t.Fail()
 	}
 

--- a/msg/message_test.go
+++ b/msg/message_test.go
@@ -22,18 +22,13 @@ func TestRequest(t *testing.T) {
 		t.Fail()
 	}
 
-	out, err := Read(&buf)
+	req, _, _, err := Read(&buf)
 	if err != nil {
 		t.Log(err.Error())
 		t.Fail()
 	}
 
-	outReq, ok := out.(*Request)
-	if !ok {
-		t.Fail()
-	}
-
-	if outReq.ID != id {
+	if req.ID != id {
 		t.Fail()
 	}
 }
@@ -53,27 +48,22 @@ func TestResponse(t *testing.T) {
 		t.Fail()
 	}
 
-	out, err := Read(&buf)
+	_, res, _, err := Read(&buf)
 	if err != nil {
 		t.Log(err.Error())
 		t.Fail()
 	}
 
-	outRes, ok := out.(*Response)
+	if res.ID != id {
+		t.Fail()
+	}
+
+	resource, ok := res.Resource.(string)
 	if !ok {
 		t.Fail()
 	}
 
-	if outRes.ID != id {
-		t.Fail()
-	}
-
-	res, ok := outRes.Resource.(string)
-	if !ok {
-		t.Fail()
-	}
-
-	if res != "resource" {
+	if resource != "resource" {
 		t.Fail()
 	}
 }
@@ -92,23 +82,18 @@ func TestPush(t *testing.T) {
 		t.Fail()
 	}
 
-	out, err := Read(&buf)
+	_, _, push, err := Read(&buf)
 	if err != nil {
 		t.Log(err.Error())
 		t.Fail()
 	}
 
-	outPush, ok := out.(*Push)
+	resource, ok := push.Resource.(string)
 	if !ok {
 		t.Fail()
 	}
 
-	res, ok := outPush.Resource.(string)
-	if !ok {
-		t.Fail()
-	}
-
-	if res != "transaction" {
+	if resource != "transaction" {
 		t.Fail()
 	}
 }


### PR DESCRIPTION
## Related Issue
#100 

## Description
* This change moves our message encoding and decoding to JSON. Specifically it changes messages so there is now a concrete `Message` type (rather than the interface we used before) that holds the payload type and the payload in byte slice form. This allows us to correctly decode the payload when a message is received. 
* Payloads can be one of `Push`, `Request`, and `Response`. 
* The `Read` function will return a `MessagePayload` (essentially just an interface that wraps the Request, Response, and Push concrete types). 
* Callers of `Read` can switch on the returned payload type to retrieve its underlying concrete type.

## WIKI Updates
* [Peer-to-Peer](https://github.com/ubclaunchpad/cumulus/wiki/Peer-to-Peer)

## Todos
None. Cuz i get werk done.