### PR TITLE
102 generate private public key from console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,14 +10,14 @@ cumulus:
 test:
 	go test $(PACKAGES) --cover
 
-run-console:
-	make clean && make cumulus && ./cumulus run -c
+run-console: cumulus
+	./cumulus run -c
 
 deps:
 	glide install
 
 clean:
-	rm cumulus || true
+	rm cumulus
 
 install-glide:
 	sh scripts/install_glide.sh

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,14 @@ cumulus:
 test:
 	go test $(PACKAGES) --cover
 
+run-console:
+	make clean && make cumulus && ./cumulus run -c
+
 deps:
 	glide install
 
 clean:
-	rm cumulus
+	rm cumulus || true
 
 install-glide:
 	sh scripts/install_glide.sh

--- a/app/app.go
+++ b/app/app.go
@@ -108,7 +108,7 @@ func Run(cfg conf.Config) {
 		if err != nil {
 			log.WithError(err).Fatal("Failed to redirect logs to file")
 		}
-		log.Warn("Redirecting logs to file")
+		log.Info("Redirecting logs to logfile")
 		log.SetOutput(logFile)
 		go RunConsole(a.PeerStore)
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -104,7 +104,7 @@ func Run(cfg conf.Config) {
 	// This should stop people from running multiple Cumulus nodes that will try
 	// to log to the same file.
 	if cfg.Console {
-		logFile, err := os.OpenFile("logfile", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0755)
+		logFile, err := os.OpenFile("logfile", os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0755)
 		if err != nil {
 			log.WithError(err).Fatal("Failed to redirect logs to file")
 		}

--- a/app/console.go
+++ b/app/console.go
@@ -6,6 +6,7 @@ import (
 	"github.com/abiosoft/ishell"
 	"github.com/ubclaunchpad/cumulus/blockchain"
 	"github.com/ubclaunchpad/cumulus/peer"
+	"gopkg.in/kyokomi/emoji.v1"
 )
 
 var (
@@ -48,7 +49,7 @@ func RunConsole(ps *peer.PeerStore) {
 	})
 
 	shell.Start()
-	shell.Println("Cumulus Console")
+	emoji.Println(":cloud: Welcome to the :sunny: Cumulus console :cloud:")
 }
 
 func create(ctx *ishell.Context) {
@@ -57,7 +58,7 @@ func create(ctx *ishell.Context) {
 		"Transaction",
 	}, "What would you like to create?")
 	if choice == 0 {
-		ctx.Println("New Wallet:", blockchain.NewWallet().Public())
+		createHotWallet(ctx)
 	} else {
 		shell.Print("Sender wallet ID: ")
 		senderID := shell.ReadLine()
@@ -109,4 +110,14 @@ func connect(ctx *ishell.Context) {
 	} else {
 		shell.Println("Connected to", addr)
 	}
+}
+
+func createHotWallet(ctx *ishell.Context) {
+	shell.Print("Enter wallet name: ")
+	walletName := shell.ReadLine()
+	wallet := HotWallet{walletName, blockchain.NewWallet()}
+	currentUser.HotWallet = wallet
+	emoji.Println(":credit_card: New hot wallet created!")
+	emoji.Println(":raising_hand: Name: " + wallet.Name)
+	emoji.Println(":mailbox: Address: " + wallet.Wallet.Public().Repr())
 }

--- a/app/user.go
+++ b/app/user.go
@@ -4,10 +4,7 @@ import "github.com/ubclaunchpad/cumulus/blockchain"
 
 // User holds basic user information.
 type User struct {
-	// Account holds the users wallet(s).
 	HotWallet
-	// UserBlockSize is the maximum size of a block in bytes when marshaled
-	// as specified by the user.
 	BlockSize uint32
 }
 

--- a/app/user.go
+++ b/app/user.go
@@ -4,11 +4,17 @@ import "github.com/ubclaunchpad/cumulus/blockchain"
 
 // User holds basic user information.
 type User struct {
-	// Wallet holds the users wallets (currently just support 1).
-	Wallet blockchain.Wallet
+	// Account holds the users wallet(s).
+	HotWallet
 	// UserBlockSize is the maximum size of a block in bytes when marshaled
 	// as specified by the user.
 	BlockSize uint32
+}
+
+// HotWallet is a representation of the users wallet.
+type HotWallet struct {
+	Name string
+	blockchain.Wallet
 }
 
 var currentUser *User
@@ -23,7 +29,10 @@ func init() {
 // NewUser creates a new user
 func NewUser() *User {
 	return &User{
-		Wallet:    blockchain.NewWallet(),
+		HotWallet: HotWallet{
+			Wallet: blockchain.NewWallet(),
+			Name:   "default",
+		},
 		BlockSize: defaultBlockSize,
 	}
 }

--- a/blockchain/blockchain_test.go
+++ b/blockchain/blockchain_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(t *testing.T) {
@@ -37,4 +38,9 @@ func TestCopyBlock(t *testing.T) {
 	if b == bc.Blocks[0] {
 		t.FailNow()
 	}
+}
+
+func TestWalletRepr(t *testing.T) {
+	w := NewWallet()
+	assert.Equal(t, len(w.Public().Repr()), 40)
 }

--- a/blockchain/wallet.go
+++ b/blockchain/wallet.go
@@ -4,6 +4,8 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	crand "crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
 	"io"
 	"math/big"
 
@@ -17,6 +19,8 @@ const (
 	AddrLen = 2 * CoordLen
 	// SigLen is the length in bytes of signatures.
 	SigLen = AddrLen
+	// AddressVersion is the version of the address shortening protocol.
+	AddressVersion = 0
 )
 
 var (
@@ -31,6 +35,28 @@ var (
 // Address represents a wallet that can be a recipient in a transaction.
 type Address struct {
 	X, Y *big.Int
+}
+
+// Repr returns a string representation of the address. We follow
+// ethereums protocol, replacing Keccak hash with SHA256.
+// Where pr is the private key.
+//    	A(pr) = SHA256(ECDSAPUBLICKEY(pr))[96:255],
+// Resources:
+// http://gavwood.com/paper.pdf (fig 213)
+func (a Address) Repr() string {
+	// 1. Concatenate X and Y and version the result.
+	concat := a.Marshal()
+	prefix := append([]byte{AddressVersion}, concat...)
+
+	// 2. Perform SHA-256 on result.
+	hash := sha256.Sum256(prefix) // 256 bit
+
+	return hex.EncodeToString(hash[96/8 : 256/8])
+}
+
+// Emoji returns the users address as a string of emojis (TODO).
+func (a Address) Emoji() string {
+	return a.Repr()
 }
 
 // Marshal converts an Address to a byte slice.

--- a/blockchain/wallet.go
+++ b/blockchain/wallet.go
@@ -39,7 +39,7 @@ type Address struct {
 
 // Repr returns a string representation of the address. We follow
 // ethereums protocol, replacing Keccak hash with SHA256.
-// Where pr is the private key.
+// Where pr is the private key,
 //    	A(pr) = SHA256(ECDSAPUBLICKEY(pr))[96:255],
 // Resources:
 // http://gavwood.com/paper.pdf (fig 213)

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 hash: 00eff548e3fa93ce1f0993837ab114a04132c04182ffeddef1e503c9e0f8026b
 updated: 2017-07-11T21:51:51.426419168-07:00
+=======
+hash: 14d7695aad2f66fada940b379240f0bd400acb153b54600074e634b009f5b271
+updated: 2017-07-23T12:50:30.990328453-07:00
+>>>>>>> added emoji; added wallet repr; added makefile things
 imports:
 - name: github.com/abiosoft/ishell
   version: a24a06e34a7a9d8f894fb339b3e77333e4fc75ac
@@ -46,11 +51,11 @@ imports:
 - name: github.com/mitchellh/mapstructure
   version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/onsi/ginkgo
-  version: 77a8c1e5c40d6bb6c5eb4dd4bdce9763564f6298
+  version: 9eda700730cba42af70d53180f9dcce9266bc2bc
   subpackages:
   - ginkgo
 - name: github.com/onsi/gomega
-  version: 334b8f472b3af5d541c5642701c1e29e2126f486
+  version: c893efa28eb45626cdaa76c9f653b62488858837
 - name: github.com/pelletier/go-toml
   version: 69d355db5304c0f7f809a2edc054553e7142f016
 - name: github.com/Sirupsen/logrus
@@ -102,6 +107,8 @@ imports:
   - internal/utf8internal
   - runes
   - internal/tag
+- name: gopkg.in/kyokomi/emoji.v1
+  version: 7e06b236c489543f53868841f188a294e3383eab
 - name: gopkg.in/yaml.v2
   version: cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b
 testImports:

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,5 @@
-<<<<<<< HEAD
-hash: 00eff548e3fa93ce1f0993837ab114a04132c04182ffeddef1e503c9e0f8026b
-updated: 2017-07-11T21:51:51.426419168-07:00
-=======
 hash: 14d7695aad2f66fada940b379240f0bd400acb153b54600074e634b009f5b271
-updated: 2017-07-23T12:50:30.990328453-07:00
->>>>>>> added emoji; added wallet repr; added makefile things
+updated: 2017-07-23T17:39:19.702683559-07:00
 imports:
 - name: github.com/abiosoft/ishell
   version: a24a06e34a7a9d8f894fb339b3e77333e4fc75ac
@@ -29,15 +24,6 @@ imports:
   - hcl/strconv
   - json/scanner
   - json/token
-- name: github.com/huin/goupnp
-  version: 73053506a919bb1af6beb97feb0d53a1eb814eb1
-  subpackages:
-  - dcps/internetgateway1
-  - dcps/internetgateway2
-  - soap
-  - httpu
-  - scpd
-  - ssdp
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/magiconair/properties
@@ -78,12 +64,6 @@ imports:
   version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
   subpackages:
   - assert
-- name: golang.org/x/net
-  version: f01ecb60fe3835d80d9a0b7b2bf24b228c89260e
-  subpackages:
-  - html/charset
-  - html
-  - html/atom
 - name: golang.org/x/sys
   version: 4ed4d404df456f81e878683a0363ed3013a59003
   subpackages:
@@ -93,20 +73,6 @@ imports:
   subpackages:
   - transform
   - unicode/norm
-  - encoding
-  - encoding/charmap
-  - encoding/htmlindex
-  - encoding/internal/identifier
-  - encoding/internal
-  - encoding/japanese
-  - encoding/korean
-  - encoding/simplifiedchinese
-  - encoding/traditionalchinese
-  - encoding/unicode
-  - language
-  - internal/utf8internal
-  - runes
-  - internal/tag
 - name: gopkg.in/kyokomi/emoji.v1
   version: 7e06b236c489543f53868841f188a294e3383eab
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,3 +17,5 @@ import:
   subpackages:
   - assert
 - package: github.com/abiosoft/ishell
+- package: gopkg.in/kyokomi/emoji.v1
+  version: ^1.5.0


### PR DESCRIPTION
## Related Issue
[102](https://github.com/ubclaunchpad/cumulus/issues/102)

## Description
* Added the ability to generate a shortened public address from the console.
* I started by using the Blockchain shortening algorithm (https://en.bitcoin.it/wiki/Technical_background_of_version_1_Bitcoin_addresses), but it seems unnecessarily complex. I switched to the Ethereum approach.
* The emoji idea is a bit more complex, and I want to do it right - so next PR.

```bash
What would you like to create?
 ❯ Wallet
   Transaction
Enter wallet name: ched
💳  New hot wallet created!
🙋  Name: ched
📫  Address: 20b58af1ae1f7640b381a9e62ab9c894dc668685
>>>
```

## WIKI Updates
* [Using-the-Console](https://github.com/ubclaunchpad/cumulus/wiki/Using-the-Console)

## Todos
+ Add emoji address.

General:
- [x] Tests - minus console tests 🤔 
- [x] Documentation (in code)
- [x] Wiki